### PR TITLE
Added holidays for New Zealand

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+
+
+- Added holidays for New Zealand
+
+
 Version 0.3.1
 =============
 

--- a/holidays.py
+++ b/holidays.py
@@ -495,8 +495,8 @@ class NewZealand(HolidayBase):
 
     def _populate(self, year):
         # Bank Holidays Act 1873
-        # The Employment of Females Act 1873 
-        # Factories Act 1894 
+        # The Employment of Females Act 1873
+        # Factories Act 1894
         # Industrial Conciliation and Arbitration Act 1894
         # Labour Day Act 1899
         # Anzac Day Act 1920, 1949, 1956
@@ -548,18 +548,18 @@ class NewZealand(HolidayBase):
         elif year > 1901:
             name = "King's Birthday"
         if year == 1952:
-             self[date(year, 6, 2)] = name # Elizabeth II
+            self[date(year, 6, 2)] = name  # Elizabeth II
         elif year > 1937:
-             self[date(year, 6, 1) + rd(weekday=MO(+1))] = name # EII & GVI 
+            self[date(year, 6, 1) + rd(weekday=MO(+1))] = name  # EII & GVI
         elif year == 1937:
-            self[date(year, 6, 9)] = name  # George VI
+            self[date(year, 6, 9)] = name   # George VI
         elif year == 1936:
-            self[date(year, 6, 23)] = name # Edward VIII
+            self[date(year, 6, 23)] = name  # Edward VIII
         elif year > 1911:
-            self[date(year, 6, 3)] = name  # George V
+            self[date(year, 6, 3)] = name   # George V
         elif year > 1901:
             # http://paperspast.natlib.govt.nz/cgi-bin/paperspast?a=d&d=NZH19091110.2.67
-            self[date(year, 11, 9)] = name # Edward VII
+            self[date(year, 11, 9)] = name  # Edward VII
 
         # Labour Day
         name = "Labour Day"
@@ -583,114 +583,100 @@ class NewZealand(HolidayBase):
             self[date(year, 12, 28)] = name + " (Observed)"
 
         # Province Anniversary Day
-        if self.prov in ('NTL', 'Northland', 'AUK', 'AKL', 'Auckland'):
+        if self.prov in ('NTL', 'Northland', 'AUK', 'AKL', 'Auckland', '*'):
             if 1963 < year <= 1973 and self.prov in ('NTL', 'Northland'):
                 name = "Waitangi Day"
                 dt = date(year, 2, 6)
             else:
                 name = "Auckland Anniversary Day"
                 dt = date(year, 1, 29)
-            self[dt] = name
             if dt.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                self[dt + rd(weekday=MO(-1))] = name + " (Observed)"
+                self[dt + rd(weekday=MO(-1))] = name
             else:
-                self[dt + rd(weekday=MO)] = name + " (Observed)"
+                self[dt + rd(weekday=MO)] = name
 
-        elif self.prov in ('TKI', 'TAR', 'Taranaki', 'New Plymouth'):
+        elif self.prov in ('TKI', 'TAR', 'Taranaki', 'New Plymouth', '*'):
             name = "Taranaki Anniversary Day"
-            self[date(year, 3, 31)] = name
-            self[date(year, 3, 1) + rd(weekday=MO(+2))] = name + " (Observed)"
+            self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
-        elif self.prov in ('HKB', 'Hawkes Bay'):
+        elif self.prov in ('HKB', 'Hawkes Bay', '*'):
             name = "Hawkes Bay Anniversary Day"
-            self[date(year, 11, 1)] = name
             labour_day = date(year, 10, 1) + rd(weekday=MO(+4))
-            self[labour_day + rd(weekday=FR(-1))] = name + " (Observed)"
+            self[labour_day + rd(weekday=FR(-1))] = name
 
-        elif self.prov in ('WGN', 'WEL', 'Wellington'):
+        elif self.prov in ('WGN', 'WEL', 'Wellington', '*'):
             name = "Wellington Anniversary Day"
             jan22 = date(year, 1, 22)
-            self[jan22] = name
             if jan22.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                self[jan22 + rd(weekday=MO(-1))] = name + " (Observed)"
+                self[jan22 + rd(weekday=MO(-1))] = name
             else:
-                self[jan22 + rd(weekday=MO)] = name + " (Observed)"
+                self[jan22 + rd(weekday=MO)] = name
 
-        elif self.prov in ('MBH', 'Marlborough'):
+        elif self.prov in ('MBH', 'Marlborough', '*'):
             name = "Marlborough Anniversary Day"
-            nov1 = date(year, 11, 1)
-            self[nov1] = name
             labour_day = date(year, 10, 1) + rd(weekday=MO(+4))
-            self[labour_day + rd(weeks=1)] = name + " (Observed)"
+            self[labour_day + rd(weeks=1)] = name
 
-        elif self.prov in ('NSN', 'NEL', 'Nelson'):
+        elif self.prov in ('NSN', 'NEL', 'Nelson', '*'):
             name = "Nelson Anniversary Day"
             feb1 = date(year, 2, 1)
-            self[feb1] = name
             if feb1.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                self[feb1 + rd(weekday=MO(-1))] = name + " (Observed)"
+                self[feb1 + rd(weekday=MO(-1))] = name
             else:
-                self[feb1 + rd(weekday=MO)] = name + " (Observed)"
+                self[feb1 + rd(weekday=MO)] = name
 
-        elif self.prov in ('CAN', 'Canterbury', 'STC', 'South Canterbury'):
+        elif self.prov in ('CAN', 'Canterbury', '*'):
             name = "Canterbury Anniversary Day"
-            dec16 = date(year, 12, 16)
-            self[dec16] = name
-            if self.prov in ('STC', 'South Canterbury'):
-                sep1 = date(year, 9, 1)
-                self[sep1 + rd(weekday=MO(4))] = name + " (Observed)"
-            else:
-                nov1 = date(year, 11, 1)
-                showday = nov1 + rd(weekday=TU) + rd(weekday=FR(+2))
-                self[showday] = name + " (Observed)"
+            showday = date(year, 11, 1) + rd(weekday=TU) + rd(weekday=FR(+2))
+            self[showday] = name
 
-        elif self.prov in ('WTC', 'WST', 'Westland', 'Greymouth'):
+        elif self.prov in ('STC', 'South Canterbury', '*'):
+            name = "South Canterbury Anniversary Day"
+            dominion_day = date(year, 9, 1) + rd(weekday=MO(4))
+            self[dominion_day] = name
+
+        elif self.prov in ('WTC', 'WST', 'Westland', 'Greymouth', '*'):
             name = "Westland Anniversary Day"
             dec1 = date(year, 12, 1)
-            self[dec1] = name
             # Observance varies?!?!
-            if year == 2005: # special case?!?!
-                self[date(year, 12, 5)] = name + " (Observed)"
+            if year == 2005:     # special case?!?!
+                self[date(year, 12, 5)] = name
             elif dec1.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                self[dec1 + rd(weekday=MO(-1))] = name + " (Observed)"
+                self[dec1 + rd(weekday=MO(-1))] = name
             else:
-                self[dec1 + rd(weekday=MO)] = name + " (Observed)"
+                self[dec1 + rd(weekday=MO)] = name
 
-        elif self.prov in ('OTA', 'Otago'):
+        elif self.prov in ('OTA', 'Otago', '*'):
             name = "Otago Anniversary Day"
             mar23 = date(year, 3, 23)
-            self[mar23] = name
-            # there is no easily determined single day of local observance?!
+            # there is no easily determined single day of local observance?!?!
             if mar23.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
                 dt = mar23 + rd(weekday=MO(-1))
             else:
                 dt = mar23 + rd(weekday=MO)
-            if dt == easter(year) + rd(weekday=MO): # Avoid Easter Monday
+            if dt == easter(year) + rd(weekday=MO):    # Avoid Easter Monday
                 dt += rd(days=1)
-            self[dt] = name + " (Observed)"
+            self[dt] = name
 
-        elif self.prov in ('STL', 'Southland'):
+        elif self.prov in ('STL', 'Southland', '*'):
             name = "Southland Anniversary Day"
             jan17 = date(year, 1, 17)
-            self[jan17] = name
             if year > 2011:
-                self[easter(year) + rd(weekday=TU)] = name + " (Observed)"
+                self[easter(year) + rd(weekday=TU)] = name
             else:
                 if jan17.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                    self[jan17 + rd(weekday=MO(-1))] = name + " (Observed)"
+                    self[jan17 + rd(weekday=MO(-1))] = name
                 else:
-                    self[jan17 + rd(weekday=MO)] = name + " (Observed)"
+                    self[jan17 + rd(weekday=MO)] = name
 
-        elif self.prov in ('CIT', 'CHA', 'Chatham Islands'):
+        elif self.prov in ('CIT', 'CHA', 'Chatham Islands', '*'):
             name = "Chatham Islands Anniversary Day"
             nov30 = date(year, 11, 30)
-            self[nov30] = name
             if nov30.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
-                self[nov30 + rd(weekday=MO(-1))] = name + " (Observed)"
+                self[nov30 + rd(weekday=MO(-1))] = name
             else:
-                self[nov30 + rd(weekday=MO)] = name + " (Observed)"
+                self[nov30 + rd(weekday=MO)] = name
 
 
 class NZ(NewZealand):
     pass
-

--- a/holidays.py
+++ b/holidays.py
@@ -15,9 +15,11 @@ from datetime import date, datetime
 from dateutil.easter import easter
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta as rd
-from dateutil.relativedelta import MO, TH, FR
+from dateutil.relativedelta import MO, TU, WE, TH, FR
 import six
 
+MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
+WEEKEND = (SATURDAY, SUNDAY)
 
 __version__ = '0.4-dev'
 
@@ -483,3 +485,212 @@ class UnitedStates(HolidayBase):
 
 class US(UnitedStates):
     pass
+
+
+class NewZealand(HolidayBase):
+
+    def __init__(self, **kwargs):
+        self.country = 'NZ'
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Bank Holidays Act 1873
+        # The Employment of Females Act 1873 
+        # Factories Act 1894 
+        # Industrial Conciliation and Arbitration Act 1894
+        # Labour Day Act 1899
+        # Anzac Day Act 1920, 1949, 1956
+        # New Zealand Day Act 1973
+        # Waitangi Day Act 1960, 1976
+        # Sovereign's Birthday Observance Act 1937, 1952
+        # Holidays Act 1981, 2003
+        if year < 1894:
+            return
+
+        # New Year's Day
+        name = "New Year's Day"
+        jan1 = date(year, 1, 1)
+        self[jan1] = name
+        if self.observed and jan1.weekday() in WEEKEND:
+            self[date(year, 1, 3)] = name + " (Observed)"
+
+        name = "Day after New Year's Day"
+        jan2 = date(year, 1, 2)
+        self[jan2] = name
+        if self.observed and jan2.weekday() in WEEKEND:
+            self[date(year, 1, 4)] = name + " (Observed)"
+
+        # Waitangi Day
+        if year > 1973:
+            name = "New Zealand Day"
+            if year > 1976:
+                name = "Waitangi Day"
+            feb6 = date(year, 2, 6)
+            self[feb6] = name
+            if self.observed and year >= 2014 and feb6.weekday() in WEEKEND:
+                self[feb6 + rd(weekday=MO)] = name + " (Observed)"
+
+        # Easter
+        self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
+        self[easter(year) + rd(weekday=MO)] = "Easter Monday"
+
+        # Anzac Day
+        if year > 1920:
+            name = "Anzac Day"
+            apr25 = date(year, 4, 25)
+            self[apr25] = name
+            if self.observed and year >= 2014 and apr25.weekday() in WEEKEND:
+                self[apr25 + rd(weekday=MO)] = name + " (Observed)"
+
+        # Sovereign's Birthday
+        if year >= 1952:
+            name = "Queen's Birthday"
+        elif year > 1901:
+            name = "King's Birthday"
+        if year == 1952:
+             self[date(year, 6, 2)] = name # Elizabeth II
+        elif year > 1937:
+             self[date(year, 6, 1) + rd(weekday=MO(+1))] = name # EII & GVI 
+        elif year == 1937:
+            self[date(year, 6, 9)] = name  # George VI
+        elif year == 1936:
+            self[date(year, 6, 23)] = name # Edward VIII
+        elif year > 1911:
+            self[date(year, 6, 3)] = name  # George V
+        elif year > 1901:
+            # http://paperspast.natlib.govt.nz/cgi-bin/paperspast?a=d&d=NZH19091110.2.67
+            self[date(year, 11, 9)] = name # Edward VII
+
+        # Labour Day
+        name = "Labour Day"
+        if year >= 1910:
+            self[date(year, 10, 1) + rd(weekday=MO(+4))] = name
+        elif year > 1899:
+            self[date(year, 10, 1) + rd(weekday=WE(+2))] = name
+
+        # Christmas Day
+        name = "Christmas Day"
+        dec25 = date(year, 12, 25)
+        self[dec25] = name
+        if self.observed and dec25.weekday() in WEEKEND:
+            self[date(year, 12, 27)] = name + " (Observed)"
+
+        # Boxing Day
+        name = "Boxing Day"
+        dec26 = date(year, 12, 26)
+        self[dec26] = name
+        if self.observed and dec26.weekday() in WEEKEND:
+            self[date(year, 12, 28)] = name + " (Observed)"
+
+        # Province Anniversary Day
+        if self.prov in ('NTL', 'Northland', 'AUK', 'AKL', 'Auckland'):
+            if 1963 < year <= 1973 and self.prov in ('NTL', 'Northland'):
+                name = "Waitangi Day"
+                dt = date(year, 2, 6)
+            else:
+                name = "Auckland Anniversary Day"
+                dt = date(year, 1, 29)
+            self[dt] = name
+            if dt.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                self[dt + rd(weekday=MO(-1))] = name + " (Observed)"
+            else:
+                self[dt + rd(weekday=MO)] = name + " (Observed)"
+
+        elif self.prov in ('TKI', 'TAR', 'Taranaki', 'New Plymouth'):
+            name = "Taranaki Anniversary Day"
+            self[date(year, 3, 31)] = name
+            self[date(year, 3, 1) + rd(weekday=MO(+2))] = name + " (Observed)"
+
+        elif self.prov in ('HKB', 'Hawkes Bay'):
+            name = "Hawkes Bay Anniversary Day"
+            self[date(year, 11, 1)] = name
+            labour_day = date(year, 10, 1) + rd(weekday=MO(+4))
+            self[labour_day + rd(weekday=FR(-1))] = name + " (Observed)"
+
+        elif self.prov in ('WGN', 'WEL', 'Wellington'):
+            name = "Wellington Anniversary Day"
+            jan22 = date(year, 1, 22)
+            self[jan22] = name
+            if jan22.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                self[jan22 + rd(weekday=MO(-1))] = name + " (Observed)"
+            else:
+                self[jan22 + rd(weekday=MO)] = name + " (Observed)"
+
+        elif self.prov in ('MBH', 'Marlborough'):
+            name = "Marlborough Anniversary Day"
+            nov1 = date(year, 11, 1)
+            self[nov1] = name
+            labour_day = date(year, 10, 1) + rd(weekday=MO(+4))
+            self[labour_day + rd(weeks=1)] = name + " (Observed)"
+
+        elif self.prov in ('NSN', 'NEL', 'Nelson'):
+            name = "Nelson Anniversary Day"
+            feb1 = date(year, 2, 1)
+            self[feb1] = name
+            if feb1.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                self[feb1 + rd(weekday=MO(-1))] = name + " (Observed)"
+            else:
+                self[feb1 + rd(weekday=MO)] = name + " (Observed)"
+
+        elif self.prov in ('CAN', 'Canterbury', 'STC', 'South Canterbury'):
+            name = "Canterbury Anniversary Day"
+            dec16 = date(year, 12, 16)
+            self[dec16] = name
+            if self.prov in ('STC', 'South Canterbury'):
+                sep1 = date(year, 9, 1)
+                self[sep1 + rd(weekday=MO(4))] = name + " (Observed)"
+            else:
+                nov1 = date(year, 11, 1)
+                showday = nov1 + rd(weekday=TU) + rd(weekday=FR(+2))
+                self[showday] = name + " (Observed)"
+
+        elif self.prov in ('WTC', 'WST', 'Westland', 'Greymouth'):
+            name = "Westland Anniversary Day"
+            dec1 = date(year, 12, 1)
+            self[dec1] = name
+            # Observance varies?!?!
+            if year == 2005: # special case?!?!
+                self[date(year, 12, 5)] = name + " (Observed)"
+            elif dec1.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                self[dec1 + rd(weekday=MO(-1))] = name + " (Observed)"
+            else:
+                self[dec1 + rd(weekday=MO)] = name + " (Observed)"
+
+        elif self.prov in ('OTA', 'Otago'):
+            name = "Otago Anniversary Day"
+            mar23 = date(year, 3, 23)
+            self[mar23] = name
+            # there is no easily determined single day of local observance?!
+            if mar23.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                dt = mar23 + rd(weekday=MO(-1))
+            else:
+                dt = mar23 + rd(weekday=MO)
+            if dt == easter(year) + rd(weekday=MO): # Avoid Easter Monday
+                dt += rd(days=1)
+            self[dt] = name + " (Observed)"
+
+        elif self.prov in ('STL', 'Southland'):
+            name = "Southland Anniversary Day"
+            jan17 = date(year, 1, 17)
+            self[jan17] = name
+            if year > 2011:
+                self[easter(year) + rd(weekday=TU)] = name + " (Observed)"
+            else:
+                if jan17.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                    self[jan17 + rd(weekday=MO(-1))] = name + " (Observed)"
+                else:
+                    self[jan17 + rd(weekday=MO)] = name + " (Observed)"
+
+        elif self.prov in ('CIT', 'CHA', 'Chatham Islands'):
+            name = "Chatham Islands Anniversary Day"
+            nov30 = date(year, 11, 30)
+            self[nov30] = name
+            if nov30.weekday() in (TUESDAY, WEDNESDAY, THURSDAY):
+                self[nov30 + rd(weekday=MO(-1))] = name + " (Observed)"
+            else:
+                self[nov30 + rd(weekday=MO)] = name + " (Observed)"
+
+
+class NZ(NewZealand):
+    pass
+

--- a/tests.py
+++ b/tests.py
@@ -767,10 +767,10 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertTrue(dt in self.holidays)
-        for year, day in enumerate([1, 1, 1, 1, 3,     # 2001-05
-                                    3, 1, 1, 1, 1,     # 2006-10
-                                    3, 3, 1, 1, 1,     # 2011-15
-                                    1, 3, 1, 1, 1, 1], # 2016-21
+        for year, day in enumerate([1, 1, 1, 1, 3,       # 2001-05
+                                    3, 1, 1, 1, 1,       # 2006-10
+                                    3, 3, 1, 1, 1,       # 2011-15
+                                    1, 3, 1, 1, 1, 1],   # 2016-21
                                    2001):
             dt = date(year, 1, day)
             self.assertTrue(dt in self.holidays)
@@ -780,10 +780,10 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 2)
             self.assertTrue(dt in self.holidays)
-        for year, day in enumerate([2, 2, 2, 2, 2,     # 2001-05
-                                    2, 2, 2, 2, 4,     # 2006-10
-                                    4, 2, 2, 2, 2,     # 2011-15
-                                    4, 2, 2, 2, 2, 4], # 2016-21
+        for year, day in enumerate([2, 2, 2, 2, 2,       # 2001-05
+                                    2, 2, 2, 2, 4,       # 2006-10
+                                    4, 2, 2, 2, 2,       # 2011-15
+                                    4, 2, 2, 2, 2, 4],   # 2016-21
                                    2001):
             dt = date(year, 1, day)
             self.assertTrue(dt in self.holidays)
@@ -792,8 +792,8 @@ class TestNZ(unittest.TestCase):
 
     def test_waitangi_day(self):
         ntl_holidays = holidays.NZ(prov='Northland')
-        for year in range(1964, 1974):
-            dt = date(year, 2, 6)
+        for year, day in enumerate([3, 8, 7, 6, 5], 1964):
+            dt = date(year, 2, day)
             self.assertTrue(dt in ntl_holidays, dt)
             self.assertEqual(ntl_holidays[dt][:8], "Waitangi")
         for year in range(1900, 1974):
@@ -802,10 +802,10 @@ class TestNZ(unittest.TestCase):
         for year in range(1974, 2100):
             dt = date(year, 2, 6)
             self.assertTrue(dt in self.holidays)
-        for year, day in enumerate([6, 6, 6, 6, 6,     # 2001-05
-                                    6, 6, 6, 6, 6,     # 2006-10
-                                    6, 6, 6, 6, 6,     # 2011-15
-                                    8, 6, 6, 6, 6, 8], # 2016-21
+        for year, day in enumerate([6, 6, 6, 6, 6,       # 2001-05
+                                    6, 6, 6, 6, 6,       # 2006-10
+                                    6, 6, 6, 6, 6,       # 2011-15
+                                    8, 6, 6, 6, 6, 8],   # 2016-21
                                    2001):
             dt = date(year, 2, day)
             self.assertTrue(dt in self.holidays)
@@ -837,10 +837,10 @@ class TestNZ(unittest.TestCase):
         for year in range(1921, 2100):
             dt = date(year, 4, 25)
             self.assertTrue(dt in self.holidays)
-        for year, day in enumerate([25, 25, 25, 25, 25,      # 2001-05
-                                    25, 25, 25, 25, 25,      # 2006-10
-                                    25, 25, 25, 25, 27,      # 2011-15
-                                    25, 25, 25, 25, 27, 26], # 2016-21
+        for year, day in enumerate([25, 25, 25, 25, 25,        # 2001-05
+                                    25, 25, 25, 25, 25,        # 2006-10
+                                    25, 25, 25, 25, 27,        # 2011-15
+                                    25, 25, 25, 25, 27, 26],   # 2016-21
                                    2001):
             dt = date(year, 4, day)
             self.assertTrue(dt in self.holidays, dt)
@@ -854,20 +854,20 @@ class TestNZ(unittest.TestCase):
             dt = date(year, 6, 3)
             self.assertTrue(dt in self.holidays)
             self.assertEqual(self.holidays[dt], "King's Birthday")
-        for year, day in enumerate([4, 3, 2, 7, 6,     # 2001-05
-                                    5, 4, 2, 1, 7,     # 2006-10
-                                    6, 4, 3, 2, 1,     # 2011-15
-                                    6, 5, 4, 3, 1, 7], # 2016-21
+        for year, day in enumerate([4, 3, 2, 7, 6,       # 2001-05
+                                    5, 4, 2, 1, 7,       # 2006-10
+                                    6, 4, 3, 2, 1,       # 2011-15
+                                    6, 5, 4, 3, 1, 7],   # 2016-21
                                    2001):
             dt = date(year, 6, day)
             self.assertTrue(dt in self.holidays, dt)
             self.assertEqual(self.holidays[dt], "Queen's Birthday")
 
     def test_labour_day(self):
-        for year, day in enumerate([22, 28, 27, 25, 24,      # 2001-05
-                                    23, 22, 27, 26, 25,      # 2006-10
-                                    24, 22, 28, 27, 26,      # 2011-15
-                                    24, 23, 22, 28, 26, 25], # 2016-21
+        for year, day in enumerate([22, 28, 27, 25, 24,        # 2001-05
+                                    23, 22, 27, 26, 25,        # 2006-10
+                                    24, 22, 28, 27, 26,        # 2011-15
+                                    24, 23, 22, 28, 26, 25],   # 2016-21
                                    2001):
             dt = date(year, 10, day)
             self.assertTrue(dt in self.holidays, dt)
@@ -885,10 +885,10 @@ class TestNZ(unittest.TestCase):
         self.holidays.observed = True
         self.assertEqual(self.holidays[date(2011, 12, 27)],
                          "Christmas Day (Observed)")
-        for year, day in enumerate([25, 25, 25, 27, 27,      # 2001-05
-                                    25, 25, 25, 25, 27,      # 2006-10
-                                    27, 25, 25, 25, 25,      # 2011-15
-                                    27, 25, 25, 25, 25, 25], # 2016-21
+        for year, day in enumerate([25, 25, 25, 27, 27,        # 2001-05
+                                    25, 25, 25, 25, 27,        # 2006-10
+                                    27, 25, 25, 25, 25,        # 2011-15
+                                    27, 25, 25, 25, 25, 25],   # 2016-21
                                    2001):
             dt = date(year, 12, day)
             self.assertTrue(dt in self.holidays, dt)
@@ -905,10 +905,10 @@ class TestNZ(unittest.TestCase):
         self.holidays.observed = True
         self.assertTrue(date(2009, 12, 28) in self.holidays)
         self.assertTrue(date(2010, 12, 27) in self.holidays)
-        for year, day in enumerate([26, 26, 26, 28, 26,      # 2001-05
-                                    26, 26, 26, 28, 28,      # 2006-10
-                                    26, 26, 26, 26, 28,      # 2011-15
-                                    26, 26, 26, 26, 28, 28], # 2016-21
+        for year, day in enumerate([26, 26, 26, 28, 26,        # 2001-05
+                                    26, 26, 26, 28, 28,        # 2006-10
+                                    26, 26, 26, 26, 28,        # 2011-15
+                                    26, 26, 26, 26, 28, 28],   # 2016-21
                                    2001):
             dt = date(year, 12, day)
             self.assertTrue(dt in self.holidays, dt)
@@ -916,177 +916,133 @@ class TestNZ(unittest.TestCase):
 
     def test_auckland_anniversary_day(self):
         auk_holidays = holidays.NZ(prov='Auckland')
-        for year in range(1900, 2100):
-            dt = date(year, 1, 29)
-            self.assertTrue(dt in auk_holidays)
-            self.assertEqual(auk_holidays[dt][:8], "Auckland")
-        for year, day in enumerate([29, 28, 27, 26, 31,      # 2001-05
-                                    30, 29, 28, 26,  1,      # 2006-10
-                                    31, 30, 28, 27, 26,      # 2011-15
-                                     1, 30, 29, 28, 27,  1], # 2016-21
+        for year, day in enumerate([29, 28, 27, 26, 31,        # 2001-05
+                                    30, 29, 28, 26,  1,        # 2006-10
+                                    31, 30, 28, 27, 26,        # 2011-15
+                                    1,  30, 29, 28, 27,  1],   # 2016-21
                                    2001):
             dt = date(year, 2 if day < 9 else 1, day)
             self.assertTrue(dt in auk_holidays, dt)
             self.assertEqual(auk_holidays[dt],
-                             "Auckland Anniversary Day (Observed)")
+                             "Auckland Anniversary Day")
 
     def test_taranaki_anniversary_day(self):
         tki_holidays = holidays.NZ(prov='Taranaki')
-        for year in range(1900, 2100):
-            dt = date(year, 3, 31)
-            self.assertTrue(dt in tki_holidays)
-            self.assertEqual(tki_holidays[dt][:8], "Taranaki")
-        for year, day in enumerate([12, 11, 10,  8, 14,      # 2001-05
-                                    13, 12, 10,  9,  8,      # 2006-10
-                                    14, 12, 11, 10,  9,      # 2011-15
-                                    14, 13, 12, 11,  9,  8], # 2016-21
+        for year, day in enumerate([12, 11, 10,  8, 14,        # 2001-05
+                                    13, 12, 10,  9,  8,        # 2006-10
+                                    14, 12, 11, 10,  9,        # 2011-15
+                                    14, 13, 12, 11,  9,  8],   # 2016-21
                                    2001):
             dt = date(year, 3, day)
             self.assertTrue(dt in tki_holidays, dt)
             self.assertEqual(tki_holidays[dt],
-                             "Taranaki Anniversary Day (Observed)")
+                             "Taranaki Anniversary Day")
 
     def test_hawkes_bay_anniversary_day(self):
         hkb_holidays = holidays.NZ(prov='Hawkes Bay')
-        for year in range(1940, 2100):
-            dt = date(year, 11, 1)
-            self.assertTrue(dt in hkb_holidays)
-            self.assertEqual(hkb_holidays[dt][:10], "Hawkes Bay")
-        for year, day in enumerate([19, 25, 24, 22, 21,      # 2001-05
-                                    20, 19, 24, 23, 22,      # 2006-10
-                                    21, 19, 25, 24, 23,      # 2011-15
-                                    21, 20, 19, 25, 23, 22], # 2016-21
+        for year, day in enumerate([19, 25, 24, 22, 21,        # 2001-05
+                                    20, 19, 24, 23, 22,        # 2006-10
+                                    21, 19, 25, 24, 23,        # 2011-15
+                                    21, 20, 19, 25, 23, 22],   # 2016-21
                                    2001):
             dt = date(year, 10, day)
             self.assertTrue(dt in hkb_holidays, dt)
             self.assertEqual(hkb_holidays[dt],
-                             "Hawkes Bay Anniversary Day (Observed)")
+                             "Hawkes Bay Anniversary Day")
 
     def test_wellington_anniversary_day(self):
         wgn_holidays = holidays.NZ(prov='Wellington')
-        for year in range(1900, 2100):
-            dt = date(year, 1, 22)
-            self.assertTrue(dt in wgn_holidays)
-            self.assertEqual(wgn_holidays[dt][:10], "Wellington")
-        for year, day in enumerate([22, 21, 20, 19, 24,      # 2001-05
-                                    23, 22, 21, 19, 25,      # 2006-10
-                                    24, 23, 21, 20, 19,      # 2011-15
-                                    25, 23, 22, 21, 20, 25], # 2016-21
+        for year, day in enumerate([22, 21, 20, 19, 24,        # 2001-05
+                                    23, 22, 21, 19, 25,        # 2006-10
+                                    24, 23, 21, 20, 19,        # 2011-15
+                                    25, 23, 22, 21, 20, 25],   # 2016-21
                                    2001):
             dt = date(year, 1, day)
             self.assertTrue(dt in wgn_holidays, dt)
             self.assertEqual(wgn_holidays[dt],
-                             "Wellington Anniversary Day (Observed)", dt)
+                             "Wellington Anniversary Day", dt)
 
     def test_marlborough_anniversary_day(self):
         mbh_holidays = holidays.NZ(prov='Marlborough')
-        for year in range(1900, 2100):
-            dt = date(year, 11, 1)
-            self.assertTrue(dt in mbh_holidays)
-            self.assertEqual(mbh_holidays[dt][:11], "Marlborough")
-        for year, day in enumerate([29,  4,  3,  1, 31,      # 2001-05
-                                    30, 29,  3,  2,  1,      # 2006-10
-                                    31, 29,  4,  3,  2,      # 2011-15
-                                    31, 30, 29,  4,  2,  1], # 2016-21
+        for year, day in enumerate([29,  4,  3,  1, 31,        # 2001-05
+                                    30, 29,  3,  2,  1,        # 2006-10
+                                    31, 29,  4,  3,  2,        # 2011-15
+                                    31, 30, 29,  4,  2,  1],   # 2016-21
                                    2001):
-            dt = date(year, 11 if day < 9 else 10 , day)
+            dt = date(year, 11 if day < 9 else 10, day)
             self.assertTrue(dt in mbh_holidays, dt)
             self.assertEqual(mbh_holidays[dt],
-                             "Marlborough Anniversary Day (Observed)", dt)
+                             "Marlborough Anniversary Day", dt)
 
     def test_nelson_anniversary_day(self):
         nsn_holidays = holidays.NZ(prov='Nelson')
-        for year in range(1900, 2100):
-            dt = date(year, 2, 1)
-            self.assertTrue(dt in nsn_holidays)
-            self.assertEqual(nsn_holidays[dt][:6], "Nelson")
-        for year, day in enumerate([29,  4,  3,  2, 31,      # 2001-05
-                                    30, 29,  4,  2,  1,      # 2006-10
-                                    31, 30,  4,  3,  2,      # 2011-15
-                                     1, 30, 29,  4,  3,  1], # 2016-21
+        for year, day in enumerate([29,  4,  3,  2, 31,        # 2001-05
+                                    30, 29,  4,  2,  1,        # 2006-10
+                                    31, 30,  4,  3,  2,        # 2011-15
+                                    1,  30, 29,  4,  3,  1],   # 2016-21
                                    2001):
-            dt = date(year, 2 if day < 9 else 1 , day)
+            dt = date(year, 2 if day < 9 else 1, day)
             self.assertTrue(dt in nsn_holidays, dt)
             self.assertEqual(nsn_holidays[dt],
-                             "Nelson Anniversary Day (Observed)", dt)
+                             "Nelson Anniversary Day", dt)
 
     def test_canterbury_anniversary_day(self):
         can_holidays = holidays.NZ(prov='Canterbury')
-        for year in range(1900, 2100):
-            dt = date(year, 12, 16)
-            self.assertTrue(dt in can_holidays)
-            self.assertEqual(can_holidays[dt][:10], "Canterbury")
-        for year, day in enumerate([16, 15, 14, 12, 11,      # 2001-05
-                                    17, 16, 14, 13, 12,      # 2006-10
-                                    11, 16, 15, 14, 13,      # 2011-15
-                                    11, 17, 16, 15, 13, 12], # 2016-21
+        for year, day in enumerate([16, 15, 14, 12, 11,        # 2001-05
+                                    17, 16, 14, 13, 12,        # 2006-10
+                                    11, 16, 15, 14, 13,        # 2011-15
+                                    11, 17, 16, 15, 13, 12],   # 2016-21
                                    2001):
             dt = date(year, 11, day)
             self.assertTrue(dt in can_holidays, dt)
             self.assertEqual(can_holidays[dt],
-                             "Canterbury Anniversary Day (Observed)", dt)
+                             "Canterbury Anniversary Day", dt)
 
     def test_south_canterbury_anniversary_day(self):
         stc_holidays = holidays.NZ(prov='South Canterbury')
-        for year in range(1940, 2100):
-            dt = date(year, 12, 16)
-            self.assertTrue(dt in stc_holidays)
-            self.assertEqual(stc_holidays[dt][:10], "Canterbury")
-        for year, day in enumerate([24, 23, 22, 27, 26,      # 2001-05
-                                    25, 24, 22, 28, 27,      # 2006-10
-                                    26, 24, 23, 22, 28,      # 2011-15
-                                    26, 25, 24, 23, 28, 27], # 2016-21
+        for year, day in enumerate([24, 23, 22, 27, 26,        # 2001-05
+                                    25, 24, 22, 28, 27,        # 2006-10
+                                    26, 24, 23, 22, 28,        # 2011-15
+                                    26, 25, 24, 23, 28, 27],   # 2016-21
                                    2001):
             dt = date(year, 9, day)
             self.assertTrue(dt in stc_holidays, dt)
             self.assertEqual(stc_holidays[dt],
-                             "Canterbury Anniversary Day (Observed)", dt)
+                             "South Canterbury Anniversary Day", dt)
 
     def test_westland_anniversary_day(self):
         wtc_holidays = holidays.NZ(prov='Westland')
-        for year in range(1940, 2100):
-            dt = date(year, 12, 1)
-            self.assertTrue(dt in wtc_holidays)
-            self.assertEqual(wtc_holidays[dt][:8], "Westland")
-        for year, day in enumerate([ 3,  2,  1, 29,  5,      # 2001-05
-                                     4,  3,  1, 30, 29,      # 2006-10
-                                    28,  3,  2,  1, 30,      # 2011-15
-                                    28,  4,  3,  2, 30, 29], # 2016-21
+        for year, day in enumerate([3,   2,  1, 29,  5,        # 2001-05
+                                    4,   3,  1, 30, 29,        # 2006-10
+                                    28,  3,  2,  1, 30,        # 2011-15
+                                    28,  4,  3,  2, 30, 29],   # 2016-21
                                    2001):
             dt = date(year, 12 if day < 9 else 11, day)
             self.assertTrue(dt in wtc_holidays, dt)
             self.assertEqual(wtc_holidays[dt],
-                             "Westland Anniversary Day (Observed)", dt)
+                             "Westland Anniversary Day", dt)
 
     def test_otago_anniversary_day(self):
         ota_holidays = holidays.NZ(prov='Otago')
-        for year in range(1900, 2100):
-            dt = date(year, 3, 23)
-            self.assertTrue(dt in ota_holidays)
-            self.assertEqual(ota_holidays[dt][:5], "Otago")
-        for year, day in enumerate([26, 25, 24, 22, 21,      # 2001-05
-                                    20, 26, 25, 23, 22,      # 2006-10
-                                    21, 26, 25, 24, 23,      # 2011-15
-                                    21, 20, 26, 25, 23, 22], # 2016-21
+        for year, day in enumerate([26, 25, 24, 22, 21,        # 2001-05
+                                    20, 26, 25, 23, 22,        # 2006-10
+                                    21, 26, 25, 24, 23,        # 2011-15
+                                    21, 20, 26, 25, 23, 22],   # 2016-21
                                    2001):
             dt = date(year, 3, day)
             self.assertTrue(dt in ota_holidays, dt)
             self.assertEqual(ota_holidays[dt],
-                             "Otago Anniversary Day (Observed)", dt)
+                             "Otago Anniversary Day", dt)
 
     def test_southland_anniversary_day(self):
         stl_holidays = holidays.NZ(prov='Southland')
-        for year in range(1940, 2100):
-            dt = date(year, 1, 17)
-            self.assertTrue(dt in stl_holidays)
-            self.assertEqual(stl_holidays[dt][:9], "Southland")
-        for year, day in enumerate([15, 14, 20, 19, 17,      # 2001-05
-                                    16, 15, 14, 19, 18, 17], # 2006-11
+        for year, day in enumerate([15, 14, 20, 19, 17,        # 2001-05
+                                    16, 15, 14, 19, 18, 17],   # 2006-11
                                    2001):
             dt = date(year, 1, day)
             self.assertTrue(dt in stl_holidays, dt)
             self.assertEqual(stl_holidays[dt],
-                             "Southland Anniversary Day (Observed)", dt)
+                             "Southland Anniversary Day", dt)
             for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
                                                  (4,  7), (3, 29), (4, 18),
                                                  (4,  3), (4, 23), (4, 14),
@@ -1094,25 +1050,20 @@ class TestNZ(unittest.TestCase):
                 dt = date(year, month, day)
                 self.assertTrue(dt in stl_holidays, dt)
                 self.assertEqual(stl_holidays[dt],
-                                 "Southland Anniversary Day (Observed)", dt)
+                                 "Southland Anniversary Day", dt)
 
     def test_chatham_islands_anniversary_day(self):
         cit_holidays = holidays.NZ(prov='Chatham Islands')
-        for year in range(1940, 2100):
-            dt = date(year, 11, 30)
-            self.assertTrue(dt in cit_holidays)
-            self.assertEqual(cit_holidays[dt][:7], "Chatham")
-        for year, day in enumerate([ 3,  2,  1, 29, 28,      # 2001-05
-                                    27,  3,  1, 30, 29,      # 2006-10
-                                    28,  3,  2,  1, 30,      # 2011-15
-                                    28, 27,  3,  2, 30, 29], # 2016-21
+        for year, day in enumerate([3,   2,  1, 29, 28,        # 2001-05
+                                    27,  3,  1, 30, 29,        # 2006-10
+                                    28,  3,  2,  1, 30,        # 2011-15
+                                    28, 27,  3,  2, 30, 29],   # 2016-21
                                    2001):
             dt = date(year, 12 if day < 9 else 11, day)
             self.assertTrue(dt in cit_holidays, dt)
             self.assertEqual(cit_holidays[dt],
-                             "Chatham Islands Anniversary Day (Observed)", dt)
+                             "Chatham Islands Anniversary Day", dt)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests.py
+++ b/tests.py
@@ -758,5 +758,361 @@ class TestUS(unittest.TestCase):
         self.assertTrue(date(2016, 12, 26) in self.holidays)
 
 
+class TestNZ(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.NZ(observed=True)
+
+    def test_new_years(self):
+        for year in range(1900, 2100):
+            dt = date(year, 1, 1)
+            self.assertTrue(dt in self.holidays)
+        for year, day in enumerate([1, 1, 1, 1, 3,     # 2001-05
+                                    3, 1, 1, 1, 1,     # 2006-10
+                                    3, 3, 1, 1, 1,     # 2011-15
+                                    1, 3, 1, 1, 1, 1], # 2016-21
+                                   2001):
+            dt = date(year, 1, day)
+            self.assertTrue(dt in self.holidays)
+            self.assertEqual(self.holidays[dt][:10], "New Year's")
+
+    def test_day_after_new_years(self):
+        for year in range(1900, 2100):
+            dt = date(year, 1, 2)
+            self.assertTrue(dt in self.holidays)
+        for year, day in enumerate([2, 2, 2, 2, 2,     # 2001-05
+                                    2, 2, 2, 2, 4,     # 2006-10
+                                    4, 2, 2, 2, 2,     # 2011-15
+                                    4, 2, 2, 2, 2, 4], # 2016-21
+                                   2001):
+            dt = date(year, 1, day)
+            self.assertTrue(dt in self.holidays)
+            self.assertEqual(self.holidays[dt][:10], "Day after ")
+        self.assertFalse(date(2016, 1, 3) in self.holidays)
+
+    def test_waitangi_day(self):
+        ntl_holidays = holidays.NZ(prov='Northland')
+        for year in range(1964, 1974):
+            dt = date(year, 2, 6)
+            self.assertTrue(dt in ntl_holidays, dt)
+            self.assertEqual(ntl_holidays[dt][:8], "Waitangi")
+        for year in range(1900, 1974):
+            dt = date(year, 2, 6)
+            self.assertFalse(dt in self.holidays)
+        for year in range(1974, 2100):
+            dt = date(year, 2, 6)
+            self.assertTrue(dt in self.holidays)
+        for year, day in enumerate([6, 6, 6, 6, 6,     # 2001-05
+                                    6, 6, 6, 6, 6,     # 2006-10
+                                    6, 6, 6, 6, 6,     # 2011-15
+                                    8, 6, 6, 6, 6, 8], # 2016-21
+                                   2001):
+            dt = date(year, 2, day)
+            self.assertTrue(dt in self.holidays)
+            self.assertEqual(self.holidays[dt][:8], "Waitangi")
+        self.assertFalse(date(2005, 2, 7) in self.holidays)
+        self.assertFalse(date(2010, 2, 8) in self.holidays)
+        self.assertFalse(date(2011, 2, 7) in self.holidays)
+
+    def test_good_friday(self):
+        for dt in [date(1900, 4, 13), date(1901, 4,  5), date(1902, 3, 28),
+                   date(1999, 4,  2), date(2000, 4, 21), date(2010, 4,  2),
+                   date(2018, 3, 30), date(2019, 4, 19), date(2020, 4, 10)]:
+            self.assertTrue(dt in self.holidays)
+            self.assertFalse(dt + relativedelta(days=-1) in self.holidays)
+            self.assertFalse(dt + relativedelta(days=+1) in self.holidays)
+
+    def test_easter_monday(self):
+        for dt in [date(1900, 4, 16), date(1901, 4,  8), date(1902, 3, 31),
+                   date(1999, 4,  5), date(2010, 4,  5),
+                   date(2018, 4,  2), date(2019, 4, 22), date(2020, 4, 13)]:
+            self.assertTrue(dt in self.holidays)
+            self.assertFalse(dt + relativedelta(days=-1) in self.holidays)
+            self.assertFalse(dt + relativedelta(days=+1) in self.holidays)
+
+    def test_anzac_day(self):
+        for year in range(1900, 1921):
+            dt = date(year, 4, 25)
+            self.assertFalse(dt in self.holidays)
+        for year in range(1921, 2100):
+            dt = date(year, 4, 25)
+            self.assertTrue(dt in self.holidays)
+        for year, day in enumerate([25, 25, 25, 25, 25,      # 2001-05
+                                    25, 25, 25, 25, 25,      # 2006-10
+                                    25, 25, 25, 25, 27,      # 2011-15
+                                    25, 25, 25, 25, 27, 26], # 2016-21
+                                   2001):
+            dt = date(year, 4, day)
+            self.assertTrue(dt in self.holidays, dt)
+            self.assertEqual(self.holidays[dt][:5], "Anzac")
+        self.assertFalse(date(2009, 4, 27) in self.holidays)
+        self.assertFalse(date(2010, 4, 26) in self.holidays)
+
+    def test_sovereigns_birthday(self):
+        self.assertTrue(date(1909, 11, 9) in self.holidays)
+        for year in range(1912, 1936):
+            dt = date(year, 6, 3)
+            self.assertTrue(dt in self.holidays)
+            self.assertEqual(self.holidays[dt], "King's Birthday")
+        for year, day in enumerate([4, 3, 2, 7, 6,     # 2001-05
+                                    5, 4, 2, 1, 7,     # 2006-10
+                                    6, 4, 3, 2, 1,     # 2011-15
+                                    6, 5, 4, 3, 1, 7], # 2016-21
+                                   2001):
+            dt = date(year, 6, day)
+            self.assertTrue(dt in self.holidays, dt)
+            self.assertEqual(self.holidays[dt], "Queen's Birthday")
+
+    def test_labour_day(self):
+        for year, day in enumerate([22, 28, 27, 25, 24,      # 2001-05
+                                    23, 22, 27, 26, 25,      # 2006-10
+                                    24, 22, 28, 27, 26,      # 2011-15
+                                    24, 23, 22, 28, 26, 25], # 2016-21
+                                   2001):
+            dt = date(year, 10, day)
+            self.assertTrue(dt in self.holidays, dt)
+            self.assertEqual(self.holidays[dt], "Labour Day")
+
+    def test_christmas_day(self):
+        self.holidays.observed = False
+        for year in range(1900, 2100):
+            dt = date(year, 12, 25)
+            self.assertTrue(dt in self.holidays)
+            self.assertFalse(dt + relativedelta(days=-1) in self.holidays)
+        self.assertFalse(date(2010, 12, 24) in self.holidays)
+        self.assertNotEqual(self.holidays[date(2011, 12, 26)],
+                            "Christmas Day (Observed)")
+        self.holidays.observed = True
+        self.assertEqual(self.holidays[date(2011, 12, 27)],
+                         "Christmas Day (Observed)")
+        for year, day in enumerate([25, 25, 25, 27, 27,      # 2001-05
+                                    25, 25, 25, 25, 27,      # 2006-10
+                                    27, 25, 25, 25, 25,      # 2011-15
+                                    27, 25, 25, 25, 25, 25], # 2016-21
+                                   2001):
+            dt = date(year, 12, day)
+            self.assertTrue(dt in self.holidays, dt)
+            self.assertEqual(self.holidays[dt][:9], "Christmas")
+
+    def test_boxing_day(self):
+        self.holidays.observed = False
+        for year in range(1900, 2100):
+            dt = date(year, 12, 26)
+            self.assertTrue(dt in self.holidays)
+            self.assertFalse(dt + relativedelta(days=+1) in self.holidays)
+        self.assertFalse(date(2009, 12, 28) in self.holidays)
+        self.assertFalse(date(2010, 12, 27) in self.holidays)
+        self.holidays.observed = True
+        self.assertTrue(date(2009, 12, 28) in self.holidays)
+        self.assertTrue(date(2010, 12, 27) in self.holidays)
+        for year, day in enumerate([26, 26, 26, 28, 26,      # 2001-05
+                                    26, 26, 26, 28, 28,      # 2006-10
+                                    26, 26, 26, 26, 28,      # 2011-15
+                                    26, 26, 26, 26, 28, 28], # 2016-21
+                                   2001):
+            dt = date(year, 12, day)
+            self.assertTrue(dt in self.holidays, dt)
+            self.assertEqual(self.holidays[dt][:6], "Boxing")
+
+    def test_auckland_anniversary_day(self):
+        auk_holidays = holidays.NZ(prov='Auckland')
+        for year in range(1900, 2100):
+            dt = date(year, 1, 29)
+            self.assertTrue(dt in auk_holidays)
+            self.assertEqual(auk_holidays[dt][:8], "Auckland")
+        for year, day in enumerate([29, 28, 27, 26, 31,      # 2001-05
+                                    30, 29, 28, 26,  1,      # 2006-10
+                                    31, 30, 28, 27, 26,      # 2011-15
+                                     1, 30, 29, 28, 27,  1], # 2016-21
+                                   2001):
+            dt = date(year, 2 if day < 9 else 1, day)
+            self.assertTrue(dt in auk_holidays, dt)
+            self.assertEqual(auk_holidays[dt],
+                             "Auckland Anniversary Day (Observed)")
+
+    def test_taranaki_anniversary_day(self):
+        tki_holidays = holidays.NZ(prov='Taranaki')
+        for year in range(1900, 2100):
+            dt = date(year, 3, 31)
+            self.assertTrue(dt in tki_holidays)
+            self.assertEqual(tki_holidays[dt][:8], "Taranaki")
+        for year, day in enumerate([12, 11, 10,  8, 14,      # 2001-05
+                                    13, 12, 10,  9,  8,      # 2006-10
+                                    14, 12, 11, 10,  9,      # 2011-15
+                                    14, 13, 12, 11,  9,  8], # 2016-21
+                                   2001):
+            dt = date(year, 3, day)
+            self.assertTrue(dt in tki_holidays, dt)
+            self.assertEqual(tki_holidays[dt],
+                             "Taranaki Anniversary Day (Observed)")
+
+    def test_hawkes_bay_anniversary_day(self):
+        hkb_holidays = holidays.NZ(prov='Hawkes Bay')
+        for year in range(1940, 2100):
+            dt = date(year, 11, 1)
+            self.assertTrue(dt in hkb_holidays)
+            self.assertEqual(hkb_holidays[dt][:10], "Hawkes Bay")
+        for year, day in enumerate([19, 25, 24, 22, 21,      # 2001-05
+                                    20, 19, 24, 23, 22,      # 2006-10
+                                    21, 19, 25, 24, 23,      # 2011-15
+                                    21, 20, 19, 25, 23, 22], # 2016-21
+                                   2001):
+            dt = date(year, 10, day)
+            self.assertTrue(dt in hkb_holidays, dt)
+            self.assertEqual(hkb_holidays[dt],
+                             "Hawkes Bay Anniversary Day (Observed)")
+
+    def test_wellington_anniversary_day(self):
+        wgn_holidays = holidays.NZ(prov='Wellington')
+        for year in range(1900, 2100):
+            dt = date(year, 1, 22)
+            self.assertTrue(dt in wgn_holidays)
+            self.assertEqual(wgn_holidays[dt][:10], "Wellington")
+        for year, day in enumerate([22, 21, 20, 19, 24,      # 2001-05
+                                    23, 22, 21, 19, 25,      # 2006-10
+                                    24, 23, 21, 20, 19,      # 2011-15
+                                    25, 23, 22, 21, 20, 25], # 2016-21
+                                   2001):
+            dt = date(year, 1, day)
+            self.assertTrue(dt in wgn_holidays, dt)
+            self.assertEqual(wgn_holidays[dt],
+                             "Wellington Anniversary Day (Observed)", dt)
+
+    def test_marlborough_anniversary_day(self):
+        mbh_holidays = holidays.NZ(prov='Marlborough')
+        for year in range(1900, 2100):
+            dt = date(year, 11, 1)
+            self.assertTrue(dt in mbh_holidays)
+            self.assertEqual(mbh_holidays[dt][:11], "Marlborough")
+        for year, day in enumerate([29,  4,  3,  1, 31,      # 2001-05
+                                    30, 29,  3,  2,  1,      # 2006-10
+                                    31, 29,  4,  3,  2,      # 2011-15
+                                    31, 30, 29,  4,  2,  1], # 2016-21
+                                   2001):
+            dt = date(year, 11 if day < 9 else 10 , day)
+            self.assertTrue(dt in mbh_holidays, dt)
+            self.assertEqual(mbh_holidays[dt],
+                             "Marlborough Anniversary Day (Observed)", dt)
+
+    def test_nelson_anniversary_day(self):
+        nsn_holidays = holidays.NZ(prov='Nelson')
+        for year in range(1900, 2100):
+            dt = date(year, 2, 1)
+            self.assertTrue(dt in nsn_holidays)
+            self.assertEqual(nsn_holidays[dt][:6], "Nelson")
+        for year, day in enumerate([29,  4,  3,  2, 31,      # 2001-05
+                                    30, 29,  4,  2,  1,      # 2006-10
+                                    31, 30,  4,  3,  2,      # 2011-15
+                                     1, 30, 29,  4,  3,  1], # 2016-21
+                                   2001):
+            dt = date(year, 2 if day < 9 else 1 , day)
+            self.assertTrue(dt in nsn_holidays, dt)
+            self.assertEqual(nsn_holidays[dt],
+                             "Nelson Anniversary Day (Observed)", dt)
+
+    def test_canterbury_anniversary_day(self):
+        can_holidays = holidays.NZ(prov='Canterbury')
+        for year in range(1900, 2100):
+            dt = date(year, 12, 16)
+            self.assertTrue(dt in can_holidays)
+            self.assertEqual(can_holidays[dt][:10], "Canterbury")
+        for year, day in enumerate([16, 15, 14, 12, 11,      # 2001-05
+                                    17, 16, 14, 13, 12,      # 2006-10
+                                    11, 16, 15, 14, 13,      # 2011-15
+                                    11, 17, 16, 15, 13, 12], # 2016-21
+                                   2001):
+            dt = date(year, 11, day)
+            self.assertTrue(dt in can_holidays, dt)
+            self.assertEqual(can_holidays[dt],
+                             "Canterbury Anniversary Day (Observed)", dt)
+
+    def test_south_canterbury_anniversary_day(self):
+        stc_holidays = holidays.NZ(prov='South Canterbury')
+        for year in range(1940, 2100):
+            dt = date(year, 12, 16)
+            self.assertTrue(dt in stc_holidays)
+            self.assertEqual(stc_holidays[dt][:10], "Canterbury")
+        for year, day in enumerate([24, 23, 22, 27, 26,      # 2001-05
+                                    25, 24, 22, 28, 27,      # 2006-10
+                                    26, 24, 23, 22, 28,      # 2011-15
+                                    26, 25, 24, 23, 28, 27], # 2016-21
+                                   2001):
+            dt = date(year, 9, day)
+            self.assertTrue(dt in stc_holidays, dt)
+            self.assertEqual(stc_holidays[dt],
+                             "Canterbury Anniversary Day (Observed)", dt)
+
+    def test_westland_anniversary_day(self):
+        wtc_holidays = holidays.NZ(prov='Westland')
+        for year in range(1940, 2100):
+            dt = date(year, 12, 1)
+            self.assertTrue(dt in wtc_holidays)
+            self.assertEqual(wtc_holidays[dt][:8], "Westland")
+        for year, day in enumerate([ 3,  2,  1, 29,  5,      # 2001-05
+                                     4,  3,  1, 30, 29,      # 2006-10
+                                    28,  3,  2,  1, 30,      # 2011-15
+                                    28,  4,  3,  2, 30, 29], # 2016-21
+                                   2001):
+            dt = date(year, 12 if day < 9 else 11, day)
+            self.assertTrue(dt in wtc_holidays, dt)
+            self.assertEqual(wtc_holidays[dt],
+                             "Westland Anniversary Day (Observed)", dt)
+
+    def test_otago_anniversary_day(self):
+        ota_holidays = holidays.NZ(prov='Otago')
+        for year in range(1900, 2100):
+            dt = date(year, 3, 23)
+            self.assertTrue(dt in ota_holidays)
+            self.assertEqual(ota_holidays[dt][:5], "Otago")
+        for year, day in enumerate([26, 25, 24, 22, 21,      # 2001-05
+                                    20, 26, 25, 23, 22,      # 2006-10
+                                    21, 26, 25, 24, 23,      # 2011-15
+                                    21, 20, 26, 25, 23, 22], # 2016-21
+                                   2001):
+            dt = date(year, 3, day)
+            self.assertTrue(dt in ota_holidays, dt)
+            self.assertEqual(ota_holidays[dt],
+                             "Otago Anniversary Day (Observed)", dt)
+
+    def test_southland_anniversary_day(self):
+        stl_holidays = holidays.NZ(prov='Southland')
+        for year in range(1940, 2100):
+            dt = date(year, 1, 17)
+            self.assertTrue(dt in stl_holidays)
+            self.assertEqual(stl_holidays[dt][:9], "Southland")
+        for year, day in enumerate([15, 14, 20, 19, 17,      # 2001-05
+                                    16, 15, 14, 19, 18, 17], # 2006-11
+                                   2001):
+            dt = date(year, 1, day)
+            self.assertTrue(dt in stl_holidays, dt)
+            self.assertEqual(stl_holidays[dt],
+                             "Southland Anniversary Day (Observed)", dt)
+            for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
+                                                 (4,  7), (3, 29), (4, 18),
+                                                 (4,  3), (4, 23), (4, 14),
+                                                 (4,  6)], 2012):
+                dt = date(year, month, day)
+                self.assertTrue(dt in stl_holidays, dt)
+                self.assertEqual(stl_holidays[dt],
+                                 "Southland Anniversary Day (Observed)", dt)
+
+    def test_chatham_islands_anniversary_day(self):
+        cit_holidays = holidays.NZ(prov='Chatham Islands')
+        for year in range(1940, 2100):
+            dt = date(year, 11, 30)
+            self.assertTrue(dt in cit_holidays)
+            self.assertEqual(cit_holidays[dt][:7], "Chatham")
+        for year, day in enumerate([ 3,  2,  1, 29, 28,      # 2001-05
+                                    27,  3,  1, 30, 29,      # 2006-10
+                                    28,  3,  2,  1, 30,      # 2011-15
+                                    28, 27,  3,  2, 30, 29], # 2016-21
+                                   2001):
+            dt = date(year, 12 if day < 9 else 11, day)
+            self.assertTrue(dt in cit_holidays, dt)
+            self.assertEqual(cit_holidays[dt],
+                             "Chatham Islands Anniversary Day (Observed)", dt)
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
This adds New Zealand as another holiday country class. Includes provincial anniversary days.