### PR TITLE
Adds German holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1333,3 +1333,107 @@ class Australia(HolidayBase):
 
 class AU(Australia):
     pass
+
+
+class Germany(HolidayBase):
+    """Official holidays for Germany in it's current form.
+
+    This class doesn't return any holidays before 1990-10-03.
+
+    Before that date the current Germany was separated into the "German
+    Democratic Republic" and the "Federal Republic of Germany" which both had
+    somewhat different holidays. Since this class is called "Germany" it
+    doesn't really make sense to include the days from the two former
+    countries.
+
+    Note that Germany doesn't have rules for holidays that happen on a
+    Sunday. Those holidays are still holiday days but there is no additional
+    day to make up for the "lost" day.
+
+    Also note that German holidays are partly declared by each province there
+    are some weired edge cases:
+
+        - "Mariä Himmelfahrt" is only a holiday in Bavaria (BY) if your
+          municipality is mothly catholic which in term depends on census data.
+          Since we don't have this data but most municipalities in Bavaria
+          *are* mostly catholic, we count that as holiday for whole Bavaria.
+        - There is an "Augsburger Friedensfest" which only exists in the town
+          Augsburg. This is excluded for Bavaria.
+        - "Gründonnerstag" (Thursday before easter) is not a holiday but pupil
+           don't have to go to school (but only in Baden Württemberg) which is
+           solved by adjusting school holidays to include this day. It is
+           excluded from our list.
+        - "Fronleichnam" is a holiday in certain, explicitly defined
+          municipalities in Saxony (SN) and Thuringia (TH). We exclude it from
+          both provinces.
+    """
+
+    PROVINCES = ['BW', 'BY', 'BE', 'BB', 'HB', 'HH', 'HE', 'MV', 'NI', 'NW',
+                 'RP', 'SL', 'SN', 'ST', 'SH', 'TH']
+
+    def __init__(self, **kwargs):
+        self.country = 'DE'
+        self.prov = kwargs.pop('prov', 'SH')
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        if year <= 1989:
+            return
+
+        if year > 1990:
+
+            self[date(year, 1, 1)] = 'Neujahr'
+
+            if self.prov in ('BW', 'BY', 'ST'):
+                self[date(year, 1, 6)] = 'Heilige Drei Könige'
+
+            self[easter(year) - rd(days=2)] = 'Karfreitag'
+
+            if self.prov == 'BB':
+                # will always be a Sunday and we have no "observed" rule so
+                # this is pretty pointless but it's nonetheless an official
+                # holiday by law
+                self[easter(year)] = 'Ostern'
+
+            self[easter(year) + rd(days=1)] = 'Ostermontag'
+
+            self[date(year, 5, 1)] = 'Maifeiertag'
+
+            self[easter(year) + rd(days=39)] = 'Christi Himmelfahrt'
+
+            if self.prov == 'BB':
+                # will always be a Sunday and we have no "observed" rule so
+                # this is pretty pointless but it's nonetheless an official
+                # holiday by law
+                self[easter(year) + rd(days=49)] = 'Pfingsten'
+
+            self[easter(year) + rd(days=50)] = 'Pfingstmontag'
+
+            if self.prov in ('BW', 'BY', 'HE', 'NW', 'RP', 'SL'):
+                self[easter(year) + rd(days=60)] = 'Fronleichnam'
+
+            if self.prov in ('BY', 'SL'):
+                self[date(year, 8, 15)] = 'Mariä Himmelfahrt'
+
+            self[date(year, 10, 3)] = 'Tag der Deutschen Einheit'
+
+        if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
+            self[date(year, 10, 31)] = 'Reformationstag'
+
+        if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
+            self[date(year, 11, 1)] = 'Allerheiligen'
+
+        if self.prov == 'SN':
+            # can be calculated as "last wednesday before year-11-23" which is
+            # why we need to go back two wednesdays if year-11-23 happens to be
+            # a wednesday
+            base_data = date(year, 11, 23)
+            weekday_delta = WE(-2) if base_data.weekday() == 2 else WE(-1)
+            self[base_data + rd(weekday=weekday_delta)] = 'Buß- und Bettag'
+
+        self[date(year, 12, 25)] = 'Erster Weihnachtstag'
+        self[date(year, 12, 26)] = 'Zweiter Weihnachtstag'
+
+
+class DE(Germany):
+    pass

--- a/tests.py
+++ b/tests.py
@@ -11,7 +11,7 @@
 #  License: MIT (see LICENSE file)
 #  Version: 0.4 (October 4, 2015)
 
-
+from itertools import product
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta, MO
 import unittest
@@ -2215,6 +2215,183 @@ class TestAU(unittest.TestCase):
                         "Boxing Day"]
         for holiday in all_holidays:
             self.assertTrue(holiday in holidays_in_2015, holiday)
+
+
+class TestDE(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.DE()
+        self.prov_hols = dict((prov, holidays.DE(prov=prov))
+                              for prov in holidays.DE.PROVINCES)
+
+    def test_no_data_before_1990(self):
+        de_1989 = sum(holidays.DE(years=[1989], prov=p)
+                      for p in holidays.DE.PROVINCES)
+        self.assertTrue(len(de_1989) == 0)
+
+    def test_all_holidays_present(self):
+        de_2015 = sum(holidays.DE(years=[2015], prov=p)
+                      for p in holidays.DE.PROVINCES)
+        in_2015 = sum((de_2015.get_list(key) for key in de_2015), [])
+        all = ["Neujahr",
+               "Heilige Drei Könige",
+               "Karfreitag",
+               "Ostern",
+               "Ostermontag",
+               "Maifeiertag",
+               "Christi Himmelfahrt",
+               "Pfingsten",
+               "Pfingstmontag",
+               "Fronleichnam",
+               "Mariä Himmelfahrt",
+               "Tag der Deutschen Einheit",
+               "Reformationstag",
+               "Allerheiligen",
+               "Buß- und Bettag",
+               "Erster Weihnachtstag",
+               "Zweiter Weihnachtstag"]
+
+        for holiday in all:
+            self.assertTrue(holiday in in_2015, "missing: {}".format(holiday))
+        for holiday in in_2015:
+            self.assertTrue(holiday in all, "extra: {}".format(holiday))
+
+    def test_fixed_holidays(self):
+        fixed_days_whole_country = (
+            (1, 1),    # Neujahr
+            (5, 1),    # Maifeiertag
+            (10, 3),   # Tag der Deutschen Einheit
+            (12, 25),  # Erster Weihnachtstag
+            (12, 26),  # Zweiter Weihnachtstag
+        )
+
+        for y, (m, d) in product(range(1991, 2050), fixed_days_whole_country):
+            self.assertTrue(date(y, m, d) in self.holidays)
+
+    def test_heilige_drei_koenige(self):
+        provinces_that_have = set(('BW', 'BY', 'ST'))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, year in product(provinces_that_have, range(1991, 2050)):
+            self.assertTrue(date(year, 1, 6) in self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(1991, 2050)):
+            self.assertTrue(date(year, 1, 6) not in self.prov_hols[province])
+
+    def test_karfreitag(self):
+        known_good = [(2014, 4, 18), (2015, 4, 3), (2016, 3, 25),
+                      (2017, 4, 14), (2018, 3, 30), (2019, 4, 19),
+                      (2020, 4, 10), (2021, 4, 2), (2022, 4, 15),
+                      (2023, 4, 7), (2024, 3, 29)]
+
+        for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+
+    def test_ostern(self):
+        known_good = [(2014, 4, 20), (2015, 4, 5), (2016, 3, 27),
+                      (2017, 4, 16), (2018, 4, 1), (2019, 4, 21),
+                      (2020, 4, 12), (2021, 4, 4), (2022, 4, 17),
+                      (2023, 4, 9), (2024, 3, 31)]
+        provinces_that_have = set(('BB',))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+
+    def test_ostermontag(self):
+        known_good = [(2014, 4, 21), (2015, 4, 6), (2016, 3, 28),
+                      (2017, 4, 17), (2018, 4, 2), (2019, 4, 22),
+                      (2020, 4, 13), (2021, 4, 5), (2022, 4, 18),
+                      (2023, 4, 10), (2024, 4, 1)]
+
+        for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+
+    def test_christi_himmelfahrt(self):
+        known_good = [(2014, 5, 29), (2015, 5, 14), (2016, 5, 5),
+                      (2017, 5, 25), (2018, 5, 10), (2019, 5, 30),
+                      (2020, 5, 21), (2021, 5, 13), (2022, 5, 26),
+                      (2023, 5, 18), (2024, 5, 9)]
+
+        for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+
+    def test_pfingsten(self):
+        known_good = [(2014, 6, 8), (2015, 5, 24), (2016, 5, 15),
+                      (2017, 6, 4), (2018, 5, 20), (2019, 6, 9),
+                      (2020, 5, 31), (2021, 5, 23), (2022, 6, 5),
+                      (2023, 5, 28), (2024, 5, 19)]
+        provinces_that_have = set(('BB',))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+
+    def test_pfingstmontag(self):
+        known_good = [(2014, 6, 9), (2015, 5, 25), (2016, 5, 16),
+                      (2017, 6, 5), (2018, 5, 21), (2019, 6, 10),
+                      (2020, 6, 1), (2021, 5, 24), (2022, 6, 6),
+                      (2023, 5, 29), (2024, 5, 20)]
+
+        for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+
+    def test_fronleichnam(self):
+        known_good = [(2014, 6, 19), (2015, 6, 4), (2016, 5, 26),
+                      (2017, 6, 15), (2018, 5, 31), (2019, 6, 20),
+                      (2020, 6, 11), (2021, 6, 3), (2022, 6, 16),
+                      (2023, 6, 8), (2024, 5, 30)]
+        provinces_that_have = set(('BW', 'BY', 'HE', 'NW', 'RP', 'SL'))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+
+    def test_mariae_himmelfahrt(self):
+        provinces_that_have = set(('BY', 'SL'))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, year in product(provinces_that_have, range(1991, 2050)):
+            self.assertTrue(date(year, 8, 15) in self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(1991, 2050)):
+            self.assertTrue(date(year, 8, 15) not in self.prov_hols[province])
+
+    def test_reformationstag(self):
+        provinces_that_have = set(('BB', 'MV', 'SN', 'ST', 'TH'))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, year in product(provinces_that_have, range(1991, 2050)):
+            self.assertTrue(date(year, 10, 31) in self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(1991, 2050)):
+            self.assertTrue(date(year, 10, 31) not in self.prov_hols[province])
+
+    def test_allerheiligen(self):
+        provinces_that_have = set(('BW', 'BY', 'NW', 'RP', 'SL'))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, year in product(provinces_that_have, range(1991, 2050)):
+            self.assertTrue(date(year, 11, 1) in self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(1991, 2050)):
+            self.assertTrue(date(year, 11, 1) not in self.prov_hols[province])
+
+    def test_buss_und_bettag(self):
+        known_good = [(2014, 11, 19), (2015, 11, 18), (2016, 11, 16),
+                      (2017, 11, 22), (2018, 11, 21), (2019, 11, 20),
+                      (2020, 11, 18), (2021, 11, 17), (2022, 11, 16),
+                      (2023, 11, 22), (2024, 11, 20)]
+        provinces_that_have = set(('SN',))
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -2252,9 +2252,9 @@ class TestDE(unittest.TestCase):
                "Zweiter Weihnachtstag"]
 
         for holiday in all:
-            self.assertTrue(holiday in in_2015, "missing: {}".format(holiday))
+            self.assertTrue(holiday in in_2015, "missing: {0}".format(holiday))
         for holiday in in_2015:
-            self.assertTrue(holiday in all, "extra: {}".format(holiday))
+            self.assertTrue(holiday in all, "extra: {0}".format(holiday))
 
     def test_fixed_holidays(self):
         fixed_days_whole_country = (


### PR DESCRIPTION
This adds all German holidays for all provinces since it's unification in 1990.
There are some special edge cases since some province specific have complicated
sub-rules but those are document in the docstring of the class.