### PR TITLE
Colombian holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -824,8 +824,8 @@ class UnitedStates(HolidayBase):
             self[date(year, 4, 22)] = "Arbor Day"
 
         # Primary Election Day
-        if self.state == 'IN' and ((year >= 2006 and year % 2 == 0)
-                                   or year >= 2015):
+        if self.state == 'IN' and ((year >= 2006 and year % 2 == 0) or
+                                   year >= 2015):
             dt = date(year, 5, 1) + rd(weekday=MO)
             self[dt + rd(days=+1)] = "Primary Election Day"
 
@@ -966,8 +966,9 @@ class UnitedStates(HolidayBase):
 
         # Election Day
         if (self.state in
-                ('DE', 'HI', 'IL', 'IN', 'LA', 'MT', 'NH', 'NJ', 'NY', 'WV')
-                and year >= 2008 and year % 2 == 0) \
+                ('DE', 'HI', 'IL', 'IN', 'LA',
+                    'MT', 'NH', 'NJ', 'NY', 'WV') and
+                year >= 2008 and year % 2 == 0) \
                 or (self.state in ('IN', 'NY') and year >= 2015):
             dt = date(year, 11, 1) + rd(weekday=MO)
             self[dt + rd(days=+1)] = "Election Day"
@@ -1006,7 +1007,8 @@ class UnitedStates(HolidayBase):
         # American Indian Heritage Day
         # Family Day
         # New Mexico Presidents' Day
-        if (self.state in ('DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV') and year >= 1975) \
+        if (self.state in ('DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV') and
+            year >= 1975) \
                 or (self.state == 'IN' and year >= 2010) \
                 or (self.state == 'MD' and year >= 2008) \
                 or self.state in ('NV', 'NM'):

--- a/holidays.py
+++ b/holidays.py
@@ -375,40 +375,52 @@ class Colombia(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
-        # Fixed holidays!
+        
+        # Fixed date holidays!
+        # If observed=True and they fall on a weekend they are not observed.
+        # If observed=False there are 18 holidays
         
         # New Year's Day
-        self[date(year, 1, 1)] = u"Año Nuevo [New Year's Day]"
+        if self.observed and date(year, 1, 1).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 1, 1)] = u"Año Nuevo [New Year's Day]"
         
         # Labor Day
-        self[date(year, 5, 1)] = u"Día del Trabajo [Labour Day]"
+        if self.observed and date(year, 5, 1).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 5, 1)] = u"Día del Trabajo [Labour Day]"
         
         # Independence Day
-        self[date(year, 7, 20)] = u"Día de la Independencia [Independence Day]"
+        if self.observed and date(year, 7, 20).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 7, 20)] = u"Día de la Independencia [Independence Day]"
         
         # Battle of Boyaca
-        self[date(year, 8, 7)] = u"Batalla de Boyacá [Battle of Boyacá]"
+        if self.observed and date(year, 8, 7).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 8, 7)] = u"Batalla de Boyacá [Battle of Boyacá]"
         
         # Immaculate Conception
-        self[date(year, 12, 8)] = u"La Inmaculada Concepción [Immaculate Conception]"
+        if self.observed and date(year, 12, 8).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 12, 8)] = u"La Inmaculada Concepción [Immaculate Conception]"
         
         # Christmas
-        name = "Navidad [Christmas]"
         if self.observed and date(year, 12, 25).weekday() in WEEKEND:
             pass
         else:
-            self[date(year, 12, 25)] = name
-        # if date(year, 12, 25).weekday() in WEEKEND:
-        #     self[date(year, 12, 25)] = name + "Fin de semana [Weekend]"
-        # else:
-        #     self[date(year, 12, 25)] = name
+            self[date(year, 12, 25)] = "Navidad [Christmas]"
         
         # Emiliani Law holidays! 
-        # (Unless it falls on a Monday it is observed the following monday.)
+        # (Unless they fall on a Monday they are observed the following monday.)
 
         #  Epiphany
         name = u"Día de los Reyes Magos [Epiphany]"
-        # newDate = self.moveToNextMon(date(year,1,6))
         if date(year,1,6).weekday()==0 or not self.observed:
             self[date(year,1,6)] = name
         else:
@@ -416,52 +428,80 @@ class Colombia(HolidayBase):
         
         # Saint Joseph's Day
         name = u"Día de San José [Saint Joseph's Day]"
-        # newDate = self.moveToNextMon(date(year,3,19))
-        self[date(year,3,19)+rd(weekday=MO)] = name
+        if date(year,3,19).weekday()==0 or not self.observed:
+            self[date(year,3,19)] = name
+        else:
+            self[date(year,3,19)+rd(weekday=MO)] = name + "(Observed)"
         
         # Saint Peter and Saint Paul's Day
         name = u"San Pedro y San Pablo [Saint Peter and Saint Paul]"
-        # newDate = self.moveToNextMon(date(year,6,29))
-        self[date(year,6,29)+rd(weekday=MO)] = name
+        if date(year,6,29).weekday()==0 or not self.observed:
+            self[date(year,6,29)] = name
+        else:
+            self[date(year,6,29)+rd(weekday=MO)] = name + "(Observed)"
         
         # Assumption of Mary
         name = u"La Asunción [Assumption of Mary]"
-        # newDate = self.moveToNextMon(date(year,8,15))
-        self[date(year,8,15)+rd(weekday=MO)] = name
+        if date(year,8,15).weekday()==0 or not self.observed:
+            self[date(year,8,15)] = name
+        else:
+            self[date(year,8,15)+rd(weekday=MO)] = name + "(Observed)"
         
         # Discovery of America
         name = u"Descubrimiento de América [Discovery of America]"
-        # newDate = self.moveToNextMon(date(year,10,12))
-        self[date(year,10,12)+rd(weekday=MO)] = name
+        if date(year,10,12).weekday()==0 or not self.observed:
+            self[date(year,10,12)] = name
+        else:
+            self[date(year,10,12)+rd(weekday=MO)] = name + "(Observed)"
         
         # All Saints’ Day
         name = u"Dia de Todos los Santos [All Saint's Day]"
-        # newDate = self.moveToNextMon(date(year,11,1))
-        self[date(year,11,1)+rd(weekday=MO)] = name
+        if date(year,11,1).weekday()==0 or not self.observed:
+            self[date(year,11,1)] = name
+        else:
+            self[date(year,11,1)+rd(weekday=MO)] = name + "(Observed)"
         
         # Independence of Cartagena
         name = u"Independencia de Cartagena [Independence of Cartagena]"
-        # newDate = self.moveToNextMon(date(year,11,11))
-        self[date(year,11,11)+rd(weekday=MO)] = name
+        if date(year,11,11).weekday()==0 or not self.observed:
+            self[date(year,11,11)] = name
+        else:
+            self[date(year,11,11)+rd(weekday=MO)] = name + "(Observed)"
         
-        # Holidays based on easter
+        # Holidays based on Easter
         
         # Maundy Thursday
-        # name = u"Jueves Santo [Maundy Thursday]"
-        # self[easter(year)+rd(days=-3)] = u"Jueves Santo [Maundy Thursday]"
         self[easter(year) + rd(weekday=TH(-1))] = u"Jueves Santo [Maundy Thursday]"
         
         # Good Friday
         self[easter(year) + rd(weekday=FR(-1))] = u"Viernes Santo [Good Friday]"
         
+        # Holidays based on Easter but are observed the following monday
+        # (unless they occur on a monday)
+        
         # Ascension of Jesus
-        self[easter(year) + rd(days=+39) + rd(weekday=MO)] = u"Ascensión del señor [Ascension of Jesus]"
+        name = u"Ascensión del señor [Ascension of Jesus]"
+        hdate = easter(year) + rd(days=+39)
+        if hdate.weekday()==0 or not self.observed:
+            self[hdate] = name
+        else:
+            self[hdate+rd(weekday=MO)] = name + "(Observed)"
         
         # Corpus Christi
-        self[easter(year) + rd(days=+60) + rd(weekday=MO)] = u"Corpus Christi [Corpus Christi]"
+        name = u"Corpus Christi [Corpus Christi]"
+        hdate = easter(year) + rd(days=+60)
+        if hdate.weekday()==0 or not self.observed:
+            self[hdate] = name
+        else:
+            self[hdate+rd(weekday=MO)] = name + "(Observed)"
         
         # Sacred Heart
-        self[easter(year) + rd(days=+68) + rd(weekday=MO)] = u"Sagrado Corazón [Sacred Heart]"
+        name = u"Sagrado Corazón [Sacred Heart]"
+        hdate = easter(year) + rd(days=+68) 
+        if hdate.weekday()==0 or not self.observed:
+            self[hdate] = name
+        else:
+            self[hdate+rd(weekday=MO)] = name + "(Observed)"
 
 
 class CO(Colombia):

--- a/holidays.py
+++ b/holidays.py
@@ -373,22 +373,6 @@ class Colombia(HolidayBase):
     def __init__(self, **kwargs):
         self.country = 'CO'
         HolidayBase.__init__(self, **kwargs)
-    
-    def moveToNextMon(self, date):
-        if date.weekday() == 1:
-            return date+rd(days=+6)
-        elif date.weekday() == 2:
-            return date+rd(days=+5)
-        elif date.weekday() == 3:
-            return date+rd(days=+4)
-        elif date.weekday() == 4:
-            return date+rd(days=+3)
-        elif date.weekday() == 5:
-            return date+rd(days=+2)
-        elif date.weekday() == 6:
-            return date+rd(days=+1)
-        else:
-            return date
 
     def _populate(self, year):
         # Fixed holidays!

--- a/holidays.py
+++ b/holidays.py
@@ -418,7 +418,7 @@ class Colombia(HolidayBase):
         if self.observed and date(year, 12, 25).weekday() in WEEKEND:
             pass
         else:
-            self[date(year, 12, 25)] = "Navidad [Christmas]"
+            self[date(year, 12, 25)] = u"Navidad [Christmas]"
 
         # Emiliani Law holidays!
         # Unless they fall on a Monday they are observed the following monday

--- a/holidays.py
+++ b/holidays.py
@@ -368,146 +368,154 @@ class Canada(HolidayBase):
 class CA(Canada):
     pass
 
+
 class Colombia(HolidayBase):
     # https://es.wikipedia.org/wiki/Anexo:D%C3%ADas_festivos_en_Colombia
+
     def __init__(self, **kwargs):
         self.country = 'CO'
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
-        
+
         # Fixed date holidays!
         # If observed=True and they fall on a weekend they are not observed.
         # If observed=False there are 18 holidays
-        
+
         # New Year's Day
         if self.observed and date(year, 1, 1).weekday() in WEEKEND:
             pass
         else:
             self[date(year, 1, 1)] = u"Año Nuevo [New Year's Day]"
-        
+
         # Labor Day
         if self.observed and date(year, 5, 1).weekday() in WEEKEND:
             pass
         else:
             self[date(year, 5, 1)] = u"Día del Trabajo [Labour Day]"
-        
+
         # Independence Day
+        name = u"Día de la Independencia [Independence Day]"
         if self.observed and date(year, 7, 20).weekday() in WEEKEND:
             pass
         else:
-            self[date(year, 7, 20)] = u"Día de la Independencia [Independence Day]"
-        
+            self[date(year, 7, 20)] = name
+
         # Battle of Boyaca
         if self.observed and date(year, 8, 7).weekday() in WEEKEND:
             pass
         else:
             self[date(year, 8, 7)] = u"Batalla de Boyacá [Battle of Boyacá]"
-        
+
         # Immaculate Conception
         if self.observed and date(year, 12, 8).weekday() in WEEKEND:
             pass
         else:
-            self[date(year, 12, 8)] = u"La Inmaculada Concepción [Immaculate Conception]"
-        
+            self[date(year, 12, 8)
+                 ] = u"La Inmaculada Concepción [Immaculate Conception]"
+
         # Christmas
         if self.observed and date(year, 12, 25).weekday() in WEEKEND:
             pass
         else:
             self[date(year, 12, 25)] = "Navidad [Christmas]"
-        
-        # Emiliani Law holidays! 
-        # (Unless they fall on a Monday they are observed the following monday.)
+
+        # Emiliani Law holidays!
+        # Unless they fall on a Monday they are observed the following monday
 
         #  Epiphany
         name = u"Día de los Reyes Magos [Epiphany]"
-        if date(year,1,6).weekday()==0 or not self.observed:
-            self[date(year,1,6)] = name
+        if date(year, 1, 6).weekday() == 0 or not self.observed:
+            self[date(year, 1, 6)] = name
         else:
-            self[date(year,1,6)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 1, 6) + rd(weekday=MO)] = name + "(Observed)"
+
         # Saint Joseph's Day
         name = u"Día de San José [Saint Joseph's Day]"
-        if date(year,3,19).weekday()==0 or not self.observed:
-            self[date(year,3,19)] = name
+        if date(year, 3, 19).weekday() == 0 or not self.observed:
+            self[date(year, 3, 19)] = name
         else:
-            self[date(year,3,19)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 3, 19) + rd(weekday=MO)] = name + "(Observed)"
+
         # Saint Peter and Saint Paul's Day
         name = u"San Pedro y San Pablo [Saint Peter and Saint Paul]"
-        if date(year,6,29).weekday()==0 or not self.observed:
-            self[date(year,6,29)] = name
+        if date(year, 6, 29).weekday() == 0 or not self.observed:
+            self[date(year, 6, 29)] = name
         else:
-            self[date(year,6,29)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 6, 29) + rd(weekday=MO)] = name + "(Observed)"
+
         # Assumption of Mary
         name = u"La Asunción [Assumption of Mary]"
-        if date(year,8,15).weekday()==0 or not self.observed:
-            self[date(year,8,15)] = name
+        if date(year, 8, 15).weekday() == 0 or not self.observed:
+            self[date(year, 8, 15)] = name
         else:
-            self[date(year,8,15)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 8, 15) + rd(weekday=MO)] = name + "(Observed)"
+
         # Discovery of America
         name = u"Descubrimiento de América [Discovery of America]"
-        if date(year,10,12).weekday()==0 or not self.observed:
-            self[date(year,10,12)] = name
+        if date(year, 10, 12).weekday() == 0 or not self.observed:
+            self[date(year, 10, 12)] = name
         else:
-            self[date(year,10,12)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 10, 12) + rd(weekday=MO)] = name + "(Observed)"
+
         # All Saints’ Day
         name = u"Dia de Todos los Santos [All Saint's Day]"
-        if date(year,11,1).weekday()==0 or not self.observed:
-            self[date(year,11,1)] = name
+        if date(year, 11, 1).weekday() == 0 or not self.observed:
+            self[date(year, 11, 1)] = name
         else:
-            self[date(year,11,1)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 11, 1) + rd(weekday=MO)] = name + "(Observed)"
+
         # Independence of Cartagena
         name = u"Independencia de Cartagena [Independence of Cartagena]"
-        if date(year,11,11).weekday()==0 or not self.observed:
-            self[date(year,11,11)] = name
+        if date(year, 11, 11).weekday() == 0 or not self.observed:
+            self[date(year, 11, 11)] = name
         else:
-            self[date(year,11,11)+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[date(year, 11, 11) + rd(weekday=MO)] = name + "(Observed)"
+
         # Holidays based on Easter
-        
+
         # Maundy Thursday
-        self[easter(year) + rd(weekday=TH(-1))] = u"Jueves Santo [Maundy Thursday]"
-        
+        self[easter(year) + rd(weekday=TH(-1))
+             ] = u"Jueves Santo [Maundy Thursday]"
+
         # Good Friday
-        self[easter(year) + rd(weekday=FR(-1))] = u"Viernes Santo [Good Friday]"
-        
+        self[easter(year) + rd(weekday=FR(-1))
+             ] = u"Viernes Santo [Good Friday]"
+
         # Holidays based on Easter but are observed the following monday
         # (unless they occur on a monday)
-        
+
         # Ascension of Jesus
         name = u"Ascensión del señor [Ascension of Jesus]"
         hdate = easter(year) + rd(days=+39)
-        if hdate.weekday()==0 or not self.observed:
+        if hdate.weekday() == 0 or not self.observed:
             self[hdate] = name
         else:
-            self[hdate+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[hdate + rd(weekday=MO)] = name + "(Observed)"
+
         # Corpus Christi
         name = u"Corpus Christi [Corpus Christi]"
         hdate = easter(year) + rd(days=+60)
-        if hdate.weekday()==0 or not self.observed:
+        if hdate.weekday() == 0 or not self.observed:
             self[hdate] = name
         else:
-            self[hdate+rd(weekday=MO)] = name + "(Observed)"
-        
+            self[hdate + rd(weekday=MO)] = name + "(Observed)"
+
         # Sacred Heart
         name = u"Sagrado Corazón [Sacred Heart]"
-        hdate = easter(year) + rd(days=+68) 
-        if hdate.weekday()==0 or not self.observed:
+        hdate = easter(year) + rd(days=+68)
+        if hdate.weekday() == 0 or not self.observed:
             self[hdate] = name
         else:
-            self[hdate+rd(weekday=MO)] = name + "(Observed)"
+            self[hdate + rd(weekday=MO)] = name + "(Observed)"
 
 
 class CO(Colombia):
     pass
 
+
 class Mexico(HolidayBase):
+
     def __init__(self, **kwargs):
         self.country = 'MX'
         HolidayBase.__init__(self, **kwargs)

--- a/holidays.py
+++ b/holidays.py
@@ -368,6 +368,120 @@ class Canada(HolidayBase):
 class CA(Canada):
     pass
 
+class Colombia(HolidayBase):
+    # https://es.wikipedia.org/wiki/Anexo:D%C3%ADas_festivos_en_Colombia
+    def __init__(self, **kwargs):
+        self.country = 'CO'
+        HolidayBase.__init__(self, **kwargs)
+    
+    def moveToNextMon(self, date):
+        if date.weekday() == 1:
+            return date+rd(days=+6)
+        elif date.weekday() == 2:
+            return date+rd(days=+5)
+        elif date.weekday() == 3:
+            return date+rd(days=+4)
+        elif date.weekday() == 4:
+            return date+rd(days=+3)
+        elif date.weekday() == 5:
+            return date+rd(days=+2)
+        elif date.weekday() == 6:
+            return date+rd(days=+1)
+        else:
+            return date
+
+    def _populate(self, year):
+        # Fixed holidays!
+        
+        # New Year's Day
+        self[date(year, 1, 1)] = u"Año Nuevo [New Year's Day]"
+        
+        # Labor Day
+        self[date(year, 5, 1)] = u"Día del Trabajo [Labour Day]"
+        
+        # Independence Day
+        self[date(year, 7, 20)] = u"Día de la Independencia [Independence Day]"
+        
+        # Battle of Boyaca
+        self[date(year, 8, 7)] = u"Batalla de Boyacá [Battle of Boyacá]"
+        
+        # Immaculate Conception
+        self[date(year, 12, 8)] = u"La Inmaculada Concepción [Immaculate Conception]"
+        
+        # Christmas
+        name = "Navidad [Christmas]"
+        if self.observed and date(year, 12, 25).weekday() in WEEKEND:
+            pass
+        else:
+            self[date(year, 12, 25)] = name
+        # if date(year, 12, 25).weekday() in WEEKEND:
+        #     self[date(year, 12, 25)] = name + "Fin de semana [Weekend]"
+        # else:
+        #     self[date(year, 12, 25)] = name
+        
+        # Emiliani Law holidays! 
+        # (Unless it falls on a Monday it is observed the following monday.)
+
+        #  Epiphany
+        name = u"Día de los Reyes Magos [Epiphany]"
+        # newDate = self.moveToNextMon(date(year,1,6))
+        if date(year,1,6).weekday()==0 or not self.observed:
+            self[date(year,1,6)] = name
+        else:
+            self[date(year,1,6)+rd(weekday=MO)] = name + "(Observed)"
+        
+        # Saint Joseph's Day
+        name = u"Día de San José [Saint Joseph's Day]"
+        # newDate = self.moveToNextMon(date(year,3,19))
+        self[date(year,3,19)+rd(weekday=MO)] = name
+        
+        # Saint Peter and Saint Paul's Day
+        name = u"San Pedro y San Pablo [Saint Peter and Saint Paul]"
+        # newDate = self.moveToNextMon(date(year,6,29))
+        self[date(year,6,29)+rd(weekday=MO)] = name
+        
+        # Assumption of Mary
+        name = u"La Asunción [Assumption of Mary]"
+        # newDate = self.moveToNextMon(date(year,8,15))
+        self[date(year,8,15)+rd(weekday=MO)] = name
+        
+        # Discovery of America
+        name = u"Descubrimiento de América [Discovery of America]"
+        # newDate = self.moveToNextMon(date(year,10,12))
+        self[date(year,10,12)+rd(weekday=MO)] = name
+        
+        # All Saints’ Day
+        name = u"Dia de Todos los Santos [All Saint's Day]"
+        # newDate = self.moveToNextMon(date(year,11,1))
+        self[date(year,11,1)+rd(weekday=MO)] = name
+        
+        # Independence of Cartagena
+        name = u"Independencia de Cartagena [Independence of Cartagena]"
+        # newDate = self.moveToNextMon(date(year,11,11))
+        self[date(year,11,11)+rd(weekday=MO)] = name
+        
+        # Holidays based on easter
+        
+        # Maundy Thursday
+        # name = u"Jueves Santo [Maundy Thursday]"
+        # self[easter(year)+rd(days=-3)] = u"Jueves Santo [Maundy Thursday]"
+        self[easter(year) + rd(weekday=TH(-1))] = u"Jueves Santo [Maundy Thursday]"
+        
+        # Good Friday
+        self[easter(year) + rd(weekday=FR(-1))] = u"Viernes Santo [Good Friday]"
+        
+        # Ascension of Jesus
+        self[easter(year) + rd(days=+39) + rd(weekday=MO)] = u"Ascensión del señor [Ascension of Jesus]"
+        
+        # Corpus Christi
+        self[easter(year) + rd(days=+60) + rd(weekday=MO)] = u"Corpus Christi [Corpus Christi]"
+        
+        # Sacred Heart
+        self[easter(year) + rd(days=+68) + rd(weekday=MO)] = u"Sagrado Corazón [Sacred Heart]"
+
+
+class CO(Colombia):
+    pass
 
 class Mexico(HolidayBase):
     def __init__(self, **kwargs):


### PR DESCRIPTION
There are three kinds of Holidays in Colombia.
- Fixed dates holidays: They are always observed on the exact date and are never observed on a weekday if they happen to fall on the weekend; e.g. christmas, new year's eve, etc.
- Emiliani law holidays: These are mostly religious holidays that are always observed on the following Monday, unless they happen to fall on a Monday.
- Easter based: These are also religious holidays, but the date is based on Easter. Some like "Good Friday" always occur on a Friday, but others like Corpus Christi are observed on the following Monday, unless it falls on a Monday.

Observed feature supported
- For the fixed date holidays, if ``observed=True`` and they fall on a weekend they are not observed.
- If ``observed=False`` there are 18 holidays in total.