### PR TITLE
Add Danish holidays and tests

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1607,3 +1607,33 @@ class Austria(HolidayBase):
 
 class AT(Austria):
     pass
+
+
+class Denmark(HolidayBase):
+    # https://en.wikipedia.org/wiki/Public_holidays_in_Denmark
+
+    def __init__(self, **kwargs):
+        self.country = 'DK'
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Public holidays
+        self[date(year, 1, 1)] = "Nytårsdag"
+        self[easter(year) + rd(weekday=TH(-1))] = "Skærtorsdag"
+        self[easter(year) + rd(weekday=FR(-1))] = "Langfredag"
+        self[easter(year)] = "Påskedag"
+        self[easter(year) + rd(weekday=MO)] = "Anden påskedag"
+        self[easter(year) + rd(weekday=FR(+4))] = "Store bededag"
+        self[easter(year) + rd(days=39)] = "Kristi himmelfartsdag"
+        self[easter(year) + rd(days=49)] = "Pinsedag"
+        self[easter(year) + rd(days=50)] = "Anden pinsedag"
+        self[date(year, 12, 25)] = "Juledag"
+        self[date(year, 12, 26)] = "Anden juledag"
+        # Other holidays (banks, most stores and offices are closed)
+        self[date(year, 6, 5)] = "Grundlovsdag"
+        self[date(year, 12, 24)] = "Juleaften"
+        self[date(year, 12, 31)] = "Nytårsaften"
+
+
+class DK(Denmark):
+    pass

--- a/holidays.py
+++ b/holidays.py
@@ -1629,10 +1629,6 @@ class Denmark(HolidayBase):
         self[easter(year) + rd(days=50)] = "Anden pinsedag"
         self[date(year, 12, 25)] = "Juledag"
         self[date(year, 12, 26)] = "Anden juledag"
-        # Other holidays (banks, most stores and offices are closed)
-        self[date(year, 6, 5)] = "Grundlovsdag"
-        self[date(year, 12, 24)] = "Juleaften"
-        self[date(year, 12, 31)] = "Nytårsaften"
 
 
 class DK(Denmark):

--- a/tests.py
+++ b/tests.py
@@ -2479,5 +2479,26 @@ class TestAT(unittest.TestCase):
             self.assertTrue(holiday in at_2015.values())
 
 
+class TestDK(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.DK()
+
+    def test_2016(self):
+        # http://www.officeholidays.com/countries/denmark/2016.php
+        self.assertTrue(date(2016, 1, 1) in self.holidays)
+        self.assertTrue(date(2016, 3, 24) in self.holidays)
+        self.assertTrue(date(2016, 3, 25) in self.holidays)
+        self.assertTrue(date(2016, 3, 28) in self.holidays)
+        self.assertTrue(date(2016, 4, 22) in self.holidays)
+        self.assertTrue(date(2016, 5, 5) in self.holidays)
+        self.assertTrue(date(2016, 5, 16) in self.holidays)
+        self.assertTrue(date(2016, 6, 5) in self.holidays)
+        self.assertTrue(date(2016, 12, 24) in self.holidays)
+        self.assertTrue(date(2016, 12, 25) in self.holidays)
+        self.assertTrue(date(2016, 12, 25) in self.holidays)
+        self.assertTrue(date(2016, 12, 31) in self.holidays)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -2493,11 +2493,7 @@ class TestDK(unittest.TestCase):
         self.assertTrue(date(2016, 4, 22) in self.holidays)
         self.assertTrue(date(2016, 5, 5) in self.holidays)
         self.assertTrue(date(2016, 5, 16) in self.holidays)
-        self.assertTrue(date(2016, 6, 5) in self.holidays)
-        self.assertTrue(date(2016, 12, 24) in self.holidays)
         self.assertTrue(date(2016, 12, 25) in self.holidays)
-        self.assertTrue(date(2016, 12, 25) in self.holidays)
-        self.assertTrue(date(2016, 12, 31) in self.holidays)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On second thought, I think it would be more correct if I remove the holidays which are not officially real holidays: Grundlovsdag ("Constitution Day"), Juleaftensdag ("Christmas Eve's Day"), and Nytårsaftensdag ("New Year's Eve's Day"). On these days most stores and offices are closing but again, they are not real holidays.