### PR TITLE
Pull version from `holidays.py` without importing it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MANIFEST
 .coverage
 *.egg-info
 *.pyc
+env*/

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,27 @@
 
 
 import codecs
+import os
+import re
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
 
+base_dir = os.path.dirname(os.path.abspath(__file__))
+
+def get_version(filename="holidays.py"):
+    with open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
+        for line in initfile.readlines():
+            m = re.match("__version__ *= *['\"](.*)['\"]", line)
+            if m:
+                return m.group(1)
+
+
 setup(
     name='holidays',
-    version='0.5',
+    version=get_version(),
     author='ryanss',
     author_email='ryanssdev@icloud.com',
     url='https://github.com/ryanss/holidays.py',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
 def get_version(filename="holidays.py"):
-    with open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
+    with codecs.open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
         for line in initfile.readlines():
             m = re.match("__version__ *= *['\"](.*)['\"]", line)
             if m:


### PR DESCRIPTION
Fixes #5

This is designed as a more elegant fix than hardcoding the version of the library in `setup.py`. It read the version from `holidays.py` (using regex) without needing to import the file.