### PR TITLE
renamed EU calendar to ECB 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,8 @@ Canada         CA      prov = AB, BC, MB, NB, NL, NS, NT, NU, **ON** (default),
                        PE, QC, SK, YU
 Colombia       CO      None
 Denmark        DK      None
-EU (TARGET2)   EU,TAR  (Trans-European Automated Real-time Gross Settlement
-                       Express Transfer System)
+ECB (TARGET2)  ECB,TAR European Central Bank
+                       (Trans-European Automated Real-time Gross Settlement
 Germany        DE      BW, BY, BE, BB, HB, HH, HE, MV, NI, NW, RP, SL, SN, ST,
                        SH, TH
 Mexico         MX      None

--- a/holidays.py
+++ b/holidays.py
@@ -1845,5 +1845,5 @@ class TAR(Target):
     pass
 
 
-class EU(Target):
+class ECB(Target):
     pass

--- a/tests.py
+++ b/tests.py
@@ -2726,5 +2726,18 @@ class TestTAR(unittest.TestCase):
             self.assertTrue(holiday in tar_2015.values())
 
 
+class TestECB(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays_ecb = holidays.ECB()
+        self.holidays_tar = holidays.TAR()
+
+    def test_new_years(self):
+        for year in range(1974, 2100):
+            self.holidays_ecb._populate(year)
+            self.holidays_tar._populate(year)
+        for holiday in self.holidays_tar:
+            self.assertTrue(holiday in self.holidays_ecb)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
TAR holidays are published by European Central Bank.
Naming EU might be ambiguous.